### PR TITLE
PRFC named parameters

### DIFF
--- a/dist/AzureC4Integration.puml
+++ b/dist/AzureC4Integration.puml
@@ -4,7 +4,7 @@
 !ifdef COMPONENT_BG_COLOR
     !define COMPONENT_LEGEND
 !else
-    !ifdef CONTAINER_BG_COLOR 
+    !ifdef CONTAINER_BG_COLOR
         !define CONTAINER_LEGEND
     !else
         !define CONTEXT_LEGEND
@@ -67,3 +67,28 @@
         endlegend
     !enddefinelong
 !endif
+
+' Elements
+' ##################################
+!$C4 = true
+' override getSprite function from C4.puml to add sprite color tag
+!function $getSprite($sprite)
+  ' if it starts with & it's a OpenIconic, details see https://useiconic.com/open/
+  ' if it starts with img: it's an image, details see https://plantuml.com/creole
+  !if (%substr($sprite, 0, 1) != "&" && %substr($sprite, 0, 4) != "img:")
+    !$formatted = "<$" + $sprite + ">"
+  !else
+    !$formatted = "<" + $sprite + ">"
+  !endif
+  !$color = %get_variable_value("$" + $sprite + "spriteColor")
+  !$formatted = "<color:" + $color + ">" + $formatted  + "</color>"
+  !return $formatted
+!endfunction
+
+UpdateElementStyle("component", $AZURE_BG_COLOR, "#000000", $AZURE_BORDER_COLOR)
+
+!procedure AzureEntity($alias, $label="",$color="#00FFFF", $techn="", $descr="", $sprite="", $tags="", $link="", $stereo="")
+  %set_variable_value("$" + $sprite + "spriteColor", $color)
+  $getElementLine("rectangle", "component", $alias, $label, $techn, $descr, $sprite, $tags, $link )
+!endprocedure
+

--- a/samples/C4 tags sample.puml
+++ b/samples/C4 tags sample.puml
@@ -1,0 +1,46 @@
+@startuml
+!pragma revision 1
+
+
+!includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Component.puml
+
+' !define AzurePuml https://raw.githubusercontent.com/plantuml-stdlib/Azure-PlantUML/master/dist
+!define AzurePuml ../dist
+
+!includeurl AzurePuml/AzureCommon.puml
+!includeurl AzurePuml/AzureC4Integration.puml
+!includeurl AzurePuml/Compute/AzureFunction.puml
+
+
+
+LAYOUT_WITH_LEGEND()
+
+' !function $getElementLine($umlShape, $elementType, $alias, $label, $techn, $descr, $sprite, $tags, $link)
+'   !$sprite=$toElementArg($sprite, $tags, "ElementTagSprite", $elementType)
+'   !$techn=$toElementArg($techn, $tags, "ElementTagTechn", $elementType)
+'   !$baseProp = $getElementBase($label, $techn, $descr, $sprite) + $getProps()
+'   !$stereo = $toStereos($elementType,$tags)
+'   !$calcLink = $getLink($link)
+  
+'   !$line = $umlShape + " " + %chr(34) + $baseProp + %chr(34) +" " + $stereo + " as " + $alias + $calcLink
+'   !return $line
+' !endfunction
+
+
+sprite $AzureFunction [70x70/16z] {
+xTE7pW8n30FWfCwjzt_XNqLX5F_2LOasPgzFbhcprVm2oWBI2F6AAgsaIiagNb6bsK82msKDQJ46jf9uYrLKyOegRQtAyYY8iGgFCg7XkhQX2esoNHSqycHe
+b4I8OQGdZAiWvUiMQEJqHnKQnS-1aKYZKOZHYDCen6Z4GACGen7dKPXHY856aGmZJgC8XX2gOZR3CEA4I8OH0uqY6KPyYySbHr5C46BOFYP69WZ9Afy3UsV0
+Y44Z8uDyV4LS8SzuTZXk3yE6c4RCjwldiBCZ4K_6vv4MiUSSPqTU6AY_PpogzjpqxMpnzXe8969xlao60uN0J3CJY6QWaGb68v8PgxX2cCb8P8Q1GgQO1OGP
+B23CB23Cu3-aFH75O3YtcxtaYKZ6UeAHdaH4a8WJaab497yMZ6IQJSS9MKci8bm5zbsY0l4AnA82yGh4Wf2rAc5V9oeGhq2imMhoony
+}
+
+
+
+' !procedure AzureFunction($alias, $label, $techn, $descr="",  $tags="", $link="", $color="")
+'   AzureEntity($alias, $label, $color, $techn, $descr, AzureFunction, $tags, $link, AzureFunction)
+' !endprocedure
+
+AddElementTag("v1.0", $borderColor="blue")
+
+AzureFunction(a,"a", "a", $tags=v1.0, $color="pink")
+@enduml

--- a/samples/C4 usage - IoT Reference Architecture - Stateful stream processing.puml
+++ b/samples/C4 usage - IoT Reference Architecture - Stateful stream processing.puml
@@ -3,10 +3,11 @@
 
 !includeurl https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
 
-!define AzurePuml https://raw.githubusercontent.com/plantuml-stdlib/Azure-PlantUML/master/dist
+' !define AzurePuml https://raw.githubusercontent.com/plantuml-stdlib/Azure-PlantUML/master/dist
+!define AzurePuml ../dist
 !includeurl AzurePuml/AzureCommon.puml
 !includeurl AzurePuml/AzureC4Integration.puml
-!includeurl AzurePuml/Compute/AzureFunction.puml
+!include ../dist/Compute/AzureFunction.puml
 !includeurl AzurePuml/Analytics/AzureStreamAnalyticsJob.puml
 !includeurl AzurePuml/Analytics/AzureEventHub.puml
 !includeurl AzurePuml/Databases/AzureCosmosDb.puml
@@ -16,8 +17,9 @@
 LAYOUT_LEFT_RIGHT
 LAYOUT_WITH_LEGEND()
 
-System(devices, "Devices")
+AddElementTag("v1.0",  $borderColor="red" )
 
+System(devices, "Devices")
 AzureIoTHub(iotHub, "IoT Hub", "Standard S1", "Ingress point for all telemetry, using built-in IoT Hub Routes for routing")
 
 AzureEventHub(eventHubTelemetry, "Device Telemetry", "Standard, 5 TUs, 4 Partitions", "In addition to the built-in 'Receive device-to-cloud messages' from IoT Hub")
@@ -25,7 +27,7 @@ AzureFunction(telemetryFunction, "Telemetry Processing", "v1, App Service plan P
 AzureCosmosDb(warmStorageCosmos, "Warm Storage", "2,000 RUs", "for consumption, e.g. display on a dashboard")
 
 AzureStreamAnalyticsJob(streamAnalytics, "Stream Analytics", "6 SUs", "apply complex queries over time periods, tolerates late (up to 21 days) and out-of-order (up to one hour) events")
-AzureFunction(alertingFunction, "Alerting", "v2, Consumption plan, JS")
+AzureFunction(alertingFunction, "Alerting", "v2, Consumption plan, JS", $tags="v1.0")
 
 AzureBlobStorage(coldBlobStorage, "Cold Storage", "General Purpose v2, Cool, RA-GRS", "all incoming data records are archived indefinitely at low cost, and are easily accessible for batch processing")
 

--- a/scripts/GeneratePuml.csproj
+++ b/scripts/GeneratePuml.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/source/AzureC4Integration.puml
+++ b/source/AzureC4Integration.puml
@@ -4,7 +4,7 @@
 !ifdef COMPONENT_BG_COLOR
     !define COMPONENT_LEGEND
 !else
-    !ifdef CONTAINER_BG_COLOR 
+    !ifdef CONTAINER_BG_COLOR
         !define CONTAINER_LEGEND
     !else
         !define CONTEXT_LEGEND
@@ -67,3 +67,29 @@
         endlegend
     !enddefinelong
 !endif
+
+' Elements
+' ##################################
+
+!$C4 = true
+' override getSprite function from C4.puml to add sprite color tag
+!function $getSprite($sprite)
+  ' if it starts with & it's a OpenIconic, details see https://useiconic.com/open/
+  ' if it starts with img: it's an image, details see https://plantuml.com/creole
+  !if (%substr($sprite, 0, 1) != "&" && %substr($sprite, 0, 4) != "img:")
+    !$formatted = "<$" + $sprite + ">"
+  !else
+    !$formatted = "<" + $sprite + ">"
+  !endif
+  !$color = %get_variable_value("$" + $sprite + "spriteColor")
+  !$formatted = "<color:" + $color + ">" + $formatted  + "</color>"
+  !return $formatted
+!endfunction
+
+UpdateElementStyle("component", $AZURE_BG_COLOR, "#000000", $AZURE_BORDER_COLOR)
+
+!procedure AzureEntity($alias, $label="",$color="#00FFFF", $techn="", $descr="", $sprite="", $tags="", $link="", $stereo="")
+  %set_variable_value("$" + $sprite + "spriteColor", $color)
+  $getElementLine("rectangle", "component", $alias, $label, $techn, $descr, $sprite, $tags, $link )
+!endprocedure
+


### PR DESCRIPTION
### Need:
As mentioned on #40 this project doesn't allow to add links or tags to the C4 components.

- Adding links allow navigation between diagrams or link to documentation (e.i using some `svg_inline` format)
- The tags are also useful because integrates with the legend and modifying some aspects too (e.i. add a custom "deprecated" tag can change the outline to be red ) 

### Proposal
Add this capabilities at least when using the `AzureC4Integration`.

### POC 
On this PR we are trying to override the `AzureEntity` inside `AzureC4Integration` to use named parameters instead allowing additional parameters easily. 

Named parameter seems to be compatibles with positional ones allowing a nice backwards compatibility. in that case maybe it worth to migrate directly to `!procedures` and `!functions`  everywhere, but now sure what are the [mentioned errors](https://github.com/plantuml-stdlib/Azure-PlantUML/issues/40#issuecomment-1210948700)

Any early feedback on this change would be appreciated 






